### PR TITLE
Bug fix in contaminant preparation when asserting entry names. 

### DIFF
--- a/contaminants/prepare.py
+++ b/contaminants/prepare.py
@@ -43,7 +43,6 @@ CACHE_DIR = 'cached'
 NOT_IN_CONTABASE = ['POLG_HRV2', 'THRB_HUMAN', 'FA10_BOVIN']
 
 def cached_urlopen(url, cache_name):
-    assert os.path.dirname(__file__) == '.', "Run it from script's directory"
     if not cache_name:
         cache_name = hashlib.sha1('abc').hexdigest()[:12]
     elif cache_name == -1:
@@ -186,7 +185,7 @@ def uniprot_names_to_acs(names):
         acs[ac] = name
     return acs
 
-def fetch_uniref_clusters(acs):
+def fetch_uniref_clusters(acs, verbose=False):
     query_url = ('http://www.uniprot.org/uniref/'
                  '?query=%s&fil=identity:1.0&format=tab')
     clusters = OrderedDict()
@@ -322,7 +321,7 @@ def write_json_file(uniprot_acs, extra_info, representants):
     with open(OUTPUT_JSON_FILE, 'w') as out:
         json.dump(data, out, indent=1, separators=(',', ': '))
 
-def main():
+def main(verbose=False):
     page = cached_urlopen(WIKI_URL, -1).readlines()
     parsed_page = parse_wiki_page(page) # { UniProt name: [some PDB IDs] }
     uniprot_acs = uniprot_names_to_acs(parsed_page) # { AC: UniProt name }
@@ -350,7 +349,7 @@ def main():
         if len(acs) == 1: # don't care about heteromers
             ac2pdb.setdefault(acs[0], []).append(p)
 
-    uniref_clusters = fetch_uniref_clusters(uniprot_acs)
+    uniref_clusters = fetch_uniref_clusters(uniprot_acs, verbose)
 
     # mapping back uniref id to uniprot name that was used an input
     uniref_sources = {}
@@ -416,4 +415,4 @@ def main():
 
 if __name__ == '__main__':
     verbose = ('-v' in sys.argv[1:])
-    main()
+    main(verbose)

--- a/contaminants/prepare.py
+++ b/contaminants/prepare.py
@@ -11,6 +11,7 @@ import json
 import math
 import os
 import re
+import ssl
 import sys
 import urllib2
 from collections import OrderedDict
@@ -52,7 +53,8 @@ def cached_urlopen(url, cache_name):
         if not os.path.isdir(CACHE_DIR):
             os.mkdir(CACHE_DIR)
         print '--> %s' % path
-        response = urllib2.urlopen(url)
+        context = ssl._create_unverified_context()
+        response = urllib2.urlopen(url, context=context)
         with open(path, 'wb') as f:
             f.write(response.read())
     return open(path)

--- a/contaminants/prepare.py
+++ b/contaminants/prepare.py
@@ -11,7 +11,7 @@ import json
 import math
 import os
 import re
-import ssl
+#import ssl
 import sys
 import urllib2
 from collections import OrderedDict
@@ -53,8 +53,9 @@ def cached_urlopen(url, cache_name):
         if not os.path.isdir(CACHE_DIR):
             os.mkdir(CACHE_DIR)
         print '--> %s' % path
-        context = ssl._create_unverified_context()
-        response = urllib2.urlopen(url, context=context)
+        #context = ssl._create_unverified_context()
+        #response = urllib2.urlopen(url, context=context)
+        response = urllib2.urlopen(url)
         with open(path, 'wb') as f:
             f.write(response.read())
     return open(path)
@@ -182,9 +183,10 @@ def uniprot_names_to_acs(names):
         response = cached_urlopen(query, 'up-%s-ie.tab' % name)
         lines = response.readlines()
         assert len(lines) >= 2, 'up-%s-ie.tab' % name
-        ac, entry_name = lines[1].strip().split('\t')
-        assert entry_name == name, '%s\n%s != %s' % (query, entry_name, name)
-        acs[ac] = name
+        for line in lines:
+            ac, entry_name = line.strip().split('\t')
+            if entry_name == name: 
+                acs[ac] = name
     return acs
 
 def fetch_uniref_clusters(acs, verbose=False):

--- a/contaminants/prepare.py
+++ b/contaminants/prepare.py
@@ -11,7 +11,6 @@ import json
 import math
 import os
 import re
-#import ssl
 import sys
 import urllib2
 from collections import OrderedDict
@@ -53,8 +52,6 @@ def cached_urlopen(url, cache_name):
         if not os.path.isdir(CACHE_DIR):
             os.mkdir(CACHE_DIR)
         print '--> %s' % path
-        #context = ssl._create_unverified_context()
-        #response = urllib2.urlopen(url, context=context)
         response = urllib2.urlopen(url)
         with open(path, 'wb') as f:
             f.write(response.read())


### PR DESCRIPTION
I was getting the following error from the prepare.py script:

[1;31m    assert entry_name == name, '%s\n%s != %s' % (query, entry_name, name)[0m
[1;31mAssertionError: http://www.uniprot.org/uniprot/?query=B4SL31_STRM5&columns=id,entry%20name&format=tab[0m
[1;31mA0A2B4SL31_STYPI != B4SL31_STRM5[0m

B4SL31_STRM5 was returning >1 result in the uniprot search so I've removed the assert clause and replaced it with a quick loop to check all the results list for the correct entry name. 