### PR TITLE
Set exitcode on phaser failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,7 +226,7 @@ def dimple(wf, opt):
                            root='phaser').run(may_fail=True)
             if not _after_phaser_comments(wf.jobs[-1],
                                           sg_in=reindexed_mtz_meta.symmetry):
-                return
+                raise RuntimeError('No phaser solution.')
             refmac_xyzin = 'phaser.1.pdb'
             f_mtz = 'phaser.1.mtz'
 


### PR DESCRIPTION
Currently dimple exits with a clean exitcode if phaser failed to come up
with a solution. Instead now raise a RuntimeError() to force an unclean
exit.

Alternatively could raise the exception in the ```_after_phaser_comments()``` function and remove its return values and the return value evaluation in ```dimple()```.