### PR TITLE
Open gzip files in text mode

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -30,7 +30,7 @@ class PdbMeta(Cell):
 
 def read_metadata(pdb, print_errors):
     if pdb.endswith('.gz'):
-        f = gzip.open(pdb, 'rb')
+        f = gzip.open(pdb, 'rt')
     else:
         f = open(pdb)
     meta = None


### PR DESCRIPTION
Without this we get a byte string, which subsequently fails when we call `line.startswith(<str>)` a few lines below.

```
$ dimple /dls/i03/data/2022/cm31105-3/processed/screening/TestLysozyme/x_15/x_15_1/ca1cf043-a60f-4e4a-a3e1-c62249e2992c/fast_dp/fast_dp.mtz /dls/i03/data/2022/cm31105-3/tmp/zocalo/screening/TestLysozyme/x_15/x_15_1/b4768c49-a5e1-45e9-bcbe-12d29ee5d662/dimple/pdb4lyz.ent.gz dimple --anode -fpng
     ### Dimple v2.6.1. Problems and suggestions: ccp4.github.io/dimple ###
MTZ (1.2A)            P 4 2 2      (78.84, 78.84, 36.96,  90, 90, 90)
Traceback (most recent call last):
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/site-packages/dimple/__main__.py", line 4, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/site-packages/dimple/main.py", line 889, in main
    dimple(wf=wf, opt=options)
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/site-packages/dimple/main.py", line 61, in dimple
    wf.read_pdb_metadata(p, print_errors=(len(opt.pdbs) > 1))
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/site-packages/dimple/workflow.py", line 692, in read_pdb_metadata
    print_errors)
  File "/dls_sw/apps/ccp4/8.0.001/ccp4-8.0/lib/python3.7/site-packages/dimple/pdb.py", line 38, in read_metadata
    if line.startswith('CRYST1'):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```