### PR TITLE
Fix: Prevent AlphaFold 1x1x1 dummy cell crashes

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,26 +50,31 @@ GOOD_FINAL_RFREE = 0.4
 def dimple(wf, opt):
 
     # --- START ALPHAFOLD PRE-PROCESSOR FIX ---
+    for i, pdb_path in enumerate(opt.pdbs):
+        if os.path.isfile(pdb_path):
+            try:
+                pdb_st = gemmi.read_structure(pdb_path)
 
-    if getattr(opt, 'pdbs', None):
-        for i, pdb_path in enumerate(opt.pdbs):
-            _st = gemmi.read_structure(pdb_path)
+                # Check for the AlphaFold dummy cell (a-axis <2)
+                if pdb_st.cell.a < 2.0:
+                    # Assign a safe, massive dummy cell
+                    # Volume = 1,000,000 A^3. rwcontents won't crash
+                    # It will NOT match the MTZ, forcing dimple to use the phaser-mr path
+                    pdb_st.cell = gemmi.UnitCell(100.0, 100.0, 100.0, 90.0, 90.0, 90.0)
+                    pdb_st.spacegroup_hm = 'P 1'
 
-            # If we detect an AlphaFold dummy cell (a-axis <2)
-            if _st.cell.a < 2.0:
-                # Assign a save, massive dummy cell
-                # Volume = 1,000,000 A^3. rwcontents won't crash
-                # It will NOT match the MTZ, forcing dimple to use the phaser-mr path
-                _st.cell = gemmi.UnitCell(100.0, 100.0, 100.0, 90.0, 90.0, 90.0)
-                _st.spacegroup_hm = 'P 1'
+                    # Write to the absolute path of the output directory
+                    new_filename = "fixed_AF_" + os.path.basename(pdb_path)
+                    absolute_out_dir = os.path.abspath(opt.output_dir)
+                    fixed_path = os.path.join(absolute_out_dir, new_filename)
+                    pdb_st.write_pdb(fixed_path)
+                    
+                    # Update Dimple's internal list to use the new patched file
+                    opt.pdbs[i] = fixed_path
 
-                # Write to the absolute path of the output directory
-                new_filename = "fixed_AF_" + os.path.basename(pdb_path)
-                absolute_out_dir = os.path.abspath(opt.output_dir)
-                fixed_path = os.path.join(absolute_out_dir, new_filename)
-                _st.write_pdb(fixed_path)
-                opt.pdbs[i] = fixed_path
-
+            except Exception as e:
+                # If gemmi fails for any reason, print a warning but don't crash
+                print(f"[*] Pre-processor warning: Could not read PDB with Gemmi ({e}). Proceeding...")
     # --- END ALPHAFOLD PRE-PROCESSOR FIX ---            
 
     

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@
 import os
 import sys
 import argparse
+import gemmi
 if __name__ == '__main__' and __package__ is None:
     sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__
                                                                        ))))
@@ -47,6 +48,31 @@ BAD_FINAL_RFREE = 0.5
 GOOD_FINAL_RFREE = 0.4
 
 def dimple(wf, opt):
+
+    # --- START ALPHAFOLD PRE-PROCESSOR FIX ---
+
+    if getattr(opt, 'pdbs', None):
+        for i, pdb_path in enumerate(opt.pdbs):
+            _st = gemmi.read_structure(pdb_path)
+
+            # If we detect an AlphaFold dummy cell (a-axis <2)
+            if _st.cell.a < 2.0:
+                # Assign a save, massive dummy cell
+                # Volume = 1,000,000 A^3. rwcontents won't crash
+                # It will NOT match the MTZ, forcing dimple to use the phaser-mr path
+                _st.cell = gemmi.UnitCell(100.0, 100.0, 100.0, 90.0, 90.0, 90.0)
+                _st.spacegroup_hm = 'P 1'
+
+                # Write to the absolute path of the output directory
+                new_filename = "fixed_AF_" + os.path.basename(pdb_path)
+                absolute_out_dir = os.path.abspath(opt.output_dir)
+                fixed_path = os.path.join(absolute_out_dir, new_filename)
+                _st.write_pdb(fixed_path)
+                opt.pdbs[i] = fixed_path
+
+    # --- END ALPHAFOLD PRE-PROCESSOR FIX ---            
+
+    
     comment('     ### Dimple v%s. Problems and suggestions:'
             ' ccp4.github.io/dimple ###' % __version__)
     mtz_meta = wf.read_mtz_metadata(opt.mtz)


### PR DESCRIPTION
AlphaFold inserts a CRYST1 line with a cell of 1 1 1 90 90 90 P1 that causes rwcontents to then crash because the contents can't possibly fit into that cell.

This fix has a pre-processor block to detect these small cells in search models and replace them with a much larger cell prior to downstream processing. This then prevents rwcontents from crashing. The inevitable difference in the unit cell and space group from the input MTZ file will result in a phaser-mr run, which is the expected behavior

The original fix for this was to remove the CRYST1 line, which would result in going to phaser-mr, but a recent update using gemmi to read the pdb file results in the CRYST1 line being written back and rwcontents failing.
